### PR TITLE
Troubleshoot 404 error on delivery rinaldi dev br

### DIFF
--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -8,7 +8,7 @@ services:
     image: nginx:alpine
     container_name: delivery_nginx
     volumes:
-      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/nginx/default.portainer.conf:/etc/nginx/conf.d/default.conf
       - ./public:/var/www/html/public:ro
       - ./storage:/var/www/html/storage:ro
     depends_on:
@@ -17,13 +17,21 @@ services:
       - rinaldi
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.delivery.rule=Host(`delivery.rinaldi.dev.br`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.delivery.rule=Host(`delivery.rinaldi.dev.br`)"
       - "traefik.http.routers.delivery.entrypoints=websecure"
       - "traefik.http.routers.delivery.tls.certresolver=letsencrypt"
       - "traefik.http.services.delivery.loadbalancer.server.port=80"
+      - "traefik.http.routers.delivery-http.rule=Host(`delivery.rinaldi.dev.br`)"
+      - "traefik.http.routers.delivery-http.entrypoints=web"
+      - "traefik.http.routers.delivery-http.service=delivery"
     restart: unless-stopped
 
   delivery_api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - APP_ENV=production
     image: delivery_api
     container_name: delivery_api
     volumes:

--- a/docker/nginx/default.portainer.conf
+++ b/docker/nginx/default.portainer.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+    root /var/www/html/public;
+    index index.php;
+
+    client_max_body_size 20M;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass delivery_api:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}


### PR DESCRIPTION
Fix 404 error on `delivery.rinaldi.dev.br` by correcting Traefik routing, Nginx `fastcgi_pass` for the `delivery_api` service, and adding its build configuration.

The 404 occurred because Traefik's rule was `PathPrefix('/api')`, preventing requests to the root domain from being routed. Additionally, Nginx's `fastcgi_pass` was misconfigured to point to `app:9000` instead of `delivery_api:9000`, and the `delivery_api` service lacked a build definition.

---
<a href="https://cursor.com/background-agent?bcId=bc-665f5b33-051f-4a1f-b63f-46fd4e39f7a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-665f5b33-051f-4a1f-b63f-46fd4e39f7a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes 404s by routing all host traffic via Traefik, switching to a new Nginx config, and adding a build config for `delivery_api`.
> 
> - **Docker/Traefik**:
>   - Update `docker-compose.portainer.yml` to route all traffic on `delivery.rinaldi.dev.br` (remove `PathPrefix('/api')`), and add an HTTP router for `web` alongside `websecure`.
>   - Mount new Nginx config `docker/nginx/default.portainer.conf` in `nginx` service.
>   - Add `delivery_api` build configuration with production args.
> - **Nginx**:
>   - Add `docker/nginx/default.portainer.conf` with `try_files` to `index.php`, `fastcgi_pass delivery_api:9000`, 20M body size, and dotfile access denial.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f7498a47db4f36037c8f488c976b15daa0520cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->